### PR TITLE
Fix decimal annotation typo

### DIFF
--- a/AllBookedUp/Shared/Product.cs
+++ b/AllBookedUp/Shared/Product.cs
@@ -13,7 +13,7 @@ namespace AllBookedUp.Shared
         public string Title { get; set; }
         public string Description { get; set; }
         public string ImageUrl { get; set; }
-        [Column(TypeName = "decimal(18,2")]
+        [Column(TypeName = "decimal(18,2)")]
         public decimal Price { get; set; }
         public Category Category { get; set; }
         public int? CategoryId { get; set; }


### PR DESCRIPTION
## Summary
- fix a typo in Product.cs where decimal column annotation was missing a closing parenthesis

## Testing
- `dotnet build AllBookedUp/AllBookedUp.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684010467ac483229c9a741bd274c34a